### PR TITLE
Formatting updates to allow parsing of these rules by both sigmac and pySigma

### DIFF
--- a/Deleting Windows Defender scheduled tasks
+++ b/Deleting Windows Defender scheduled tasks
@@ -1,7 +1,7 @@
 title: Deleting Windows Defender scheduled tasks
 status: Experimental
 description: Detects the deletion of scheduled tasks related to Windows Defender.
-author: \@Kostastsale, \@TheDFIRReport
+author: '@Kostastsale, @TheDFIRReport'
 references: 
   - https://thedfirreport.com/2022/05/09/seo-poisoning-a-gootloader-story/
 date: 2022/05/09

--- a/Enabling RDP service via reg.exe command execution
+++ b/Enabling RDP service via reg.exe command execution
@@ -1,7 +1,7 @@
 title:  Enabling RDP service via reg.exe command execution
 status: Experimental
 description: Detects the execution of reg.exe and subsequent command line arguments for enabling RDP service on the host 
-author: @Kostastsale, @TheDFIRReport
+author: '@Kostastsale, @TheDFIRReport'
 references: 
   - https://thedfirreport.com/2022/02/21/qbot-and-zerologon-lead-to-full-domain-compromise/
 date: 2022/02/12

--- a/Enabling restricted admin mode
+++ b/Enabling restricted admin mode
@@ -1,7 +1,7 @@
 title: Enabling restricted admin mode
 status: Experimental
 description: Detects the registry modification to enable restricted admin mode using reg.exe
-author: \@Kostastsale, \@TheDFIRReport
+author: '@Kostastsale, @TheDFIRReport'
 references: 
   - https://thedfirreport.com/2022/05/09/seo-poisoning-a-gootloader-story/
 date: 2022/05/09

--- a/Execution of ZeroLogon PoC executable
+++ b/Execution of ZeroLogon PoC executable
@@ -1,7 +1,7 @@
 title: Execution of ZeroLogon PoC executable
 status: Experimental
 description: Detects the execution of the commonly used ZeroLogon PoC executable.
-author: @Kostastsale, @TheDFIRReport
+author: '@Kostastsale, @TheDFIRReport'
 references: 
   - https://thedfirreport.com/2021/11/01/from-zero-to-domain-admin/
   - https://thedfirreport.com/2022/02/21/qbot-and-zerologon-lead-to-full-domain-compromise/

--- a/PSEXEC Custom Named Service Binary
+++ b/PSEXEC Custom Named Service Binary
@@ -3,7 +3,7 @@ status: experimental
 description: PSEXEC execututed with non default service binary name
 references:
     - thedfirreport.com
-author: @TheDFIRReport
+author: '@TheDFIRReport'
 date: 2022/04/24
 logsource:
     product: windows

--- a/QBot Exec via Scheduled Task with C$
+++ b/QBot Exec via Scheduled Task with C$
@@ -3,25 +3,26 @@ id: 014da553-5727-4e47-9544-56da83b3eb6f
 description: Detects the creation of Scheduled Task with REGSVR32 (regsvr32.exe) and C$ in the image path field
 status: test
 author: tas_kmanager, TheDFIRReport
-references:https://thedfirreport.com/2022/02/07/qbot-likes-to-move-it-move-it/
+references: https://thedfirreport.com/2022/02/07/qbot-likes-to-move-it-move-it/
 date: 2022/02/06
 modified: 2022/02/06
 logsource:
-product: windows
-service: system
+  product: windows
+  service: system
 detection:
-selection:
-Provider_Name: 'Service Control Manager'
-EventID: 7045
-ImagePath|contains|all: 
-- 'regsvr32.exe'
-- 'C$'
-condition: selection
+  selection:
+    Provider_Name: 'Service Control Manager'
+    EventID: 7045
+    ImagePath|contains|all: 
+      - 'regsvr32.exe'
+      - 'C$'
+  condition: selection
 level: high
 falsepositives:
-- low
+  - low
 tags:
-- attack.persistence
-- attack.privilege_escalation
-- attack.t1053.005
-- qbot
+  - attack.persistence
+  - attack.privilege_escalation
+  - attack.t1053.005
+  - attack.S0650
+  - attack.qbot

--- a/Qbot Exec via Scheduled Task
+++ b/Qbot Exec via Scheduled Task
@@ -3,24 +3,25 @@ id: 33d9c3f4-57a6-4ddb-a2a0-b2ccf8482607
 status: test
 description: Detects the process creation from Scheduled Task with REGSVR32 (regsvr32.exe), -s flag and SYSTEM in the command line 
 author: tas_kmanager, TheDFIRReport
-references:https://thedfirreport.com/2022/02/07/qbot-likes-to-move-it-move-it/
+references: https://thedfirreport.com/2022/02/07/qbot-likes-to-move-it-move-it/
 date: 2022/02/06
 modified: 2022/02/06
 logsource:
-category: process_creation
-product: windows
+  category: process_creation
+  product: windows
 detection:
-selection:
-CommandLine|contains|all: 
-- 'schtasks.exe'
-- 'regsvr32.exe -s'
-- 'SYSTEM'
-condition: selection
+  selection:
+    CommandLine|contains|all: 
+      - 'schtasks.exe'
+      - 'regsvr32.exe -s'
+      - 'SYSTEM'
+  condition: selection
 falsepositives:
-- unknown
+  - unknown
 level: high
 tags:
-- attack.persistence
-- attack.privilege_escalation
-- attack.t1053.005
-- qbot
+  - attack.persistence
+  - attack.privilege_escalation
+  - attack.t1053.005
+  - attack.S0650
+  - attack.qbot

--- a/Scheduled task executing powershell encoded payload from registry
+++ b/Scheduled task executing powershell encoded payload from registry
@@ -1,7 +1,7 @@
 title: Scheduled task executing powershell encoded payload from registry
 status: Experimental
 description: Detects the creation of a schtask that executes a base64 encoded payload stored in the Windows Registry using PowerShell.
-author: @Kostastsale, @TheDFIRReport
+author: '@Kostastsale, @TheDFIRReport'
 references: 
   - https://thedfirreport.com/2022/02/21/qbot-and-zerologon-lead-to-full-domain-compromise/
 date: 2022/02/12
@@ -22,7 +22,7 @@ detection:
       - 'HKCU:'
   condition: selection1 and selection2
 falsepositives:
-  - Uknown
+  - Unknown
 level: high
 tags:
   - attack.execution

--- a/Using Lazagne to dump credentials
+++ b/Using Lazagne to dump credentials
@@ -1,55 +1,55 @@
 title: Using Lazagne to dump credentials
 status: Experimental
 description: Detects the use of lazagne looking into the command line execution.
-author: \@Kostastsale, \@TheDFIRReport
+author: '@Kostastsale, @TheDFIRReport'
 references:
 - https://thedfirreport.com/2022/05/09/seo-poisoning-a-gootloader-story/
 - https://github.com/AlessandroZ/LaZagne/blob/master/Windows/lazagne/config/execute_cmd.py
 date: 2022/05/09
 logsource:
-product: windows
-category: process_creation
+  product: windows
+  category: process_creation
 detection:
-selection1:
-Image|endswith:
-- '\cmd.exe'
-- '\powershell.exe'
-CommandLine|contains|all:
-- '/c'
-- 'reg.exe'
-- 'save'
-ParentCommandLine|contains:
-- 'all'
-selection2:
-ParentCommandLine|contains:
-- '-oN'
-- '-oA'
-- '-oJ'
-- '-quiet'
-- '-output'
-CommandLine|contains:
-- 'hklm\system'
-- 'hklm\security'
-- 'hklm\sam'
-modules:
-Image|endswith:
-- '\lazagne.exe'
-CommandLine|contains:
-- 'browsers'
-- 'chats'
-- 'databases'
-- 'games'
-- 'memory'
-- 'git'
-- 'maven'
-- 'sysadmin'
-- 'php'
-- 'svn'
-- 'multimedia'
-condition: (selection1 and selection2) or modules
+  selection1:
+    Image|endswith:
+      - '\cmd.exe'
+      - '\powershell.exe'
+    CommandLine|contains|all:
+      - '/c'
+      - 'reg.exe'
+      - 'save'
+    ParentCommandLine|contains:
+      - 'all'
+  selection2:
+    ParentCommandLine|contains:
+      - '-oN'
+      - '-oA'
+      - '-oJ'
+      - '-quiet'
+      - '-output'
+    CommandLine|contains:
+      - 'hklm\system'
+      - 'hklm\security'
+      - 'hklm\sam'
+  modules:
+    Image|endswith:
+      - '\lazagne.exe'
+    CommandLine|contains:
+      - 'browsers'
+      - 'chats'
+      - 'databases'
+      - 'games'
+      - 'memory'
+      - 'git'
+      - 'maven'
+      - 'sysadmin'
+      - 'php'
+      - 'svn'
+      - 'multimedia'
+  condition: (selection1 and selection2) or modules
 falsepositives:
-- Uknown
+  - Uknown
 level: high
 tags:
-- attack.credential_access
-- attack.t1555
+  - attack.credential_access
+  - attack.t1555

--- a/Using powershell specific download cradle OneLiner
+++ b/Using powershell specific download cradle OneLiner
@@ -1,28 +1,28 @@
 title: Custom Cobalt Strike Execution
 status: Experimental
 description: Detects the execution of a specific OneLiner to Invoke PowerShell commands.
-author: \@Kostastsale, \@TheDFIRReport
+author: '@Kostastsale, @TheDFIRReport'
 references:
-- https://thedfirreport.com/2022/05/09/seo-poisoning-a-gootloader-story/
-- https://gist.github.com/mgeeky/3b11169ab77a7de354f4111aa2f0df38
+  - https://thedfirreport.com/2022/05/09/seo-poisoning-a-gootloader-story/
+  - https://gist.github.com/mgeeky/3b11169ab77a7de354f4111aa2f0df38
 date: 2022/05/09
 logsource:
-product: windows
-category: process_creation
+  product: windows
+  category: process_creation
 detection:
-selection1:
-Image|endswith:
-- '\powershell.exe'
-CommandLine|contains|all:
-- 'http://127.0.0.1'
-- '%{(IRM $_)}'
-- 'Invoke'
-condition: selection1
+  selection1:
+    Image|endswith:
+      - '\powershell.exe'
+    CommandLine|contains|all:
+      - 'http://127.0.0.1'
+      - '%{(IRM $_)}'
+      - 'Invoke'
+  condition: selection1
 falsepositives:
-- Uknown
+  - Uknown
 level: high
 tags:
-- attack.defense_evasion
-- attack.t1562.001
-- attack.execution
-- T1059.001
+  - attack.defense_evasion
+  - attack.t1562.001
+  - attack.execution
+  - T1059.001


### PR DESCRIPTION
# Overview
These Sigma rules are fantastic! However, I had some issues parsing them using both the legacy sigmac conversion and the pySigma codebase.

## Author values starting with '@'
In most cases, this was a result of the author value starting with the @ symbol, which apparently is not allowed in yaml 🤷. In these cases I simply enclosed the author value in single quotes. See before:
![image](https://user-images.githubusercontent.com/63474467/168395801-37fd6009-57ac-416d-8172-1b8bd666e394.png)

and after:
![image](https://user-images.githubusercontent.com/63474467/168395834-174d11dc-2136-4a62-b539-0095fbeca4c1.png)

## Indentation issue
Some of the rules needed to have the various rule elements indented so they could be parsed by Sigma. See before:
![image](https://user-images.githubusercontent.com/63474467/168396140-7ab42d63-aea3-49a0-90ff-fa1fd94e2923.png)

vs after:
![image](https://user-images.githubusercontent.com/63474467/168396173-3822f549-c953-43ad-bc36-f3d0af9675a8.png)

## Issue with tags in QBot rules
Lastly, the Sigma rule specification requires that tags be delimited, and so rules with tags without a period will not be able to be parsed. This is sort of explained [here](https://github.com/SigmaHQ/sigma/wiki/Specification#tags). For the QBot rules, I updated the tags with the Mitre ATT&CK software designation for QakBot:
  - attack.persistence
  - attack.privilege_escalation
  - attack.t1053.005
  - attack.S0650
  - attack.qbot

That's it - thanks for all you do! I am a huge fan of your work.