### PR TITLE
Adding IDs to all rules

### DIFF
--- a/Deleting Windows Defender scheduled tasks
+++ b/Deleting Windows Defender scheduled tasks
@@ -1,4 +1,5 @@
 title: Deleting Windows Defender scheduled tasks
+id: 2a6239f4-fefa-4080-adba-196f8006b54e
 status: Experimental
 description: Detects the deletion of scheduled tasks related to Windows Defender.
 author: '@Kostastsale, @TheDFIRReport'

--- a/Enabling RDP service via reg.exe command execution
+++ b/Enabling RDP service via reg.exe command execution
@@ -1,4 +1,5 @@
 title:  Enabling RDP service via reg.exe command execution
+id: ded07dbe-bcd4-4d15-a27b-1669445d3215
 status: Experimental
 description: Detects the execution of reg.exe and subsequent command line arguments for enabling RDP service on the host 
 author: '@Kostastsale, @TheDFIRReport'

--- a/Enabling restricted admin mode
+++ b/Enabling restricted admin mode
@@ -1,4 +1,5 @@
 title: Enabling restricted admin mode
+id: 8e9de57d-7c2e-4ce7-8f5d-56e9f1de475f
 status: Experimental
 description: Detects the registry modification to enable restricted admin mode using reg.exe
 author: '@Kostastsale, @TheDFIRReport'

--- a/Execution of ZeroLogon PoC executable
+++ b/Execution of ZeroLogon PoC executable
@@ -1,4 +1,5 @@
 title: Execution of ZeroLogon PoC executable
+id: fe0c3029-c6df-4f0b-9b82-e4ca4b9659f0
 status: Experimental
 description: Detects the execution of the commonly used ZeroLogon PoC executable.
 author: '@Kostastsale, @TheDFIRReport'

--- a/PSEXEC Custom Named Service Binary
+++ b/PSEXEC Custom Named Service Binary
@@ -1,4 +1,5 @@
 title: PSEXEC Custom Named Service Binary
+id: 752956d6-cf16-43f5-a8ca-b82f968e458d
 status: experimental
 description: PSEXEC execututed with non default service binary name
 references:

--- a/SSH over port 443 with known Server and Client Strings
+++ b/SSH over port 443 with known Server and Client Strings
@@ -1,4 +1,5 @@
 title: SSH over port 443 with known Server and Client Strings
+id: 3c5791a2-8f29-413d-b511-90918ecb33b7
 status: Experimental
 description: Will detect the presence of known SSH client and SSH server strings that have been used for SSH tunneling.
 author: \@iiamaleks,\@TheDFIRReport

--- a/Webshell Usage with ManageEngine SupportCenter Plus
+++ b/Webshell Usage with ManageEngine SupportCenter Plus
@@ -1,4 +1,5 @@
 title: Webshell Usage with ManageEngine Product
+id: c1717e0b-e364-4032-bb8e-1bd112ba4058
 status: Experimental
 description: Detection of a webshell in a ManageEngine internet accessible directory.
 author: \@iiamaleks,\@TheDFIRReport

--- a/adfind_discovery
+++ b/adfind_discovery
@@ -1,4 +1,5 @@
 title: AdFind Discovery
+id: 50046619-1037-49d7-91aa-54fc92923604
 description: AdFind has been seen in numerous intrusions. The threat actor(s) ran these commands.
 author: 'The DFIR Report, @thedfirreport'
 date: 2022/5/14

--- a/custom_cobalt_strike_command_execution
+++ b/custom_cobalt_strike_command_execution
@@ -1,4 +1,5 @@
 title: Custom Cobalt Strike Command Execution
+id: 782de568-fadb-4e7f-b89a-64247a606830
 status: Experimental
 description: Detects the execution of a specific OneLiner to Invoke PowerShell commands.
 author: '@Kostastsale, @TheDFIRReport'

--- a/defaultaccount_usage
+++ b/defaultaccount_usage
@@ -1,4 +1,5 @@
 title: DefaultAccount Usage
+id: dca5d253-d738-4ec4-b530-381ece784d42
 description: Threat actor (APT35) created user, enabled it, set password, add to admins and remote desktop users.
 author: 'The DFIR Report, @thedfirreport'
 date: 2022/5/14

--- a/exchange_webshell_creation
+++ b/exchange_webshell_creation
@@ -1,4 +1,5 @@
 title: Exchange Webshell creation
+id: 3086329b-245b-4b91-a0f7-bed9b5438cf6
 description: These commands were used to create a webshell by exploiting ProxyShell vulnerabilities
 author: 'The DFIR Report, @thedfirreport'
 date: 2022/5/14

--- a/lazagne_dumping_credentials
+++ b/lazagne_dumping_credentials
@@ -1,4 +1,5 @@
 title: Lazagne dumping credentials
+id: ce435e85-f322-494c-b11d-7f03201e7da7
 status: Experimental
 description: Detects the use of lazagne using  command line execution.
 author: '@Kostastsale, @TheDFIRReport'

--- a/mimkiatz_command_line_with_ticket_export
+++ b/mimkiatz_command_line_with_ticket_export
@@ -1,4 +1,5 @@
 title: Mimikatz Command Line With Ticket Export
+id: 48e1dd43-c42f-4b3b-9011-a0ea1fab6b03
 description: Detection of well-known mimikatz command line arguments. Added more commandline indicators from referenced rule by author - Teymur Kheirkhabarov, oscd.community
 author: thedfirreport
 date: 2021/01/18

--- a/scheduled_task_executing_powershell_ecoded_payload_from_registry
+++ b/scheduled_task_executing_powershell_ecoded_payload_from_registry
@@ -1,4 +1,5 @@
 title: Scheduled task executing powershell encoded payload from registry
+id: 16e0c76d-dbe9-461b-afce-ced21d819b29
 status: Experimental
 description: Detects the creation of a schtask that executes a base64 encoded payload stored in the Windows Registry using PowerShell.
 author: '@Kostastsale, @TheDFIRReport'

--- a/win_chcp_codepage_locale_lookup.yml
+++ b/win_chcp_codepage_locale_lookup.yml
@@ -1,4 +1,5 @@
 title: CHCP CodePage Locale Lookup
+id: dfbdd206-6cf2-4db9-93a6-0b7e14d5f02f
 status: Experimental
 description: Detects use of chcp to look up the system locale value as part of host discovery
 author: _pete_0, TheDFIRReport

--- a/win_cobaltstrike_operator_bloopers_modules.yml
+++ b/win_cobaltstrike_operator_bloopers_modules.yml
@@ -1,4 +1,5 @@
 title: Operator Bloopers Cobalt Strike Modules
+id: 507249b7-7adc-4cda-8edd-8577b431bee3
 status: Experimental
 description: Detects use of Cobalt Strike module commands accidentally entered in the CMD shell
 author: _pete_0, TheDFIRReport

--- a/win_suspicious_commands_by_sql_server.yml
+++ b/win_suspicious_commands_by_sql_server.yml
@@ -1,4 +1,5 @@
 title: Suspicious Commands by SQL Server
+id: 9a73f4cc-a727-4b26-a9d8-81d2724b7f5e
 description: Detects suspicious commands created from sqlservr process.
 status: experimental
 author: @TheDFIRReport


### PR DESCRIPTION
Added v4 UUIDs per SigmaHQ docs to some of the rules so that they can be tracked, especially using tools such as SigmaDiff