### PR TITLE
Wrong tag

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_adfind_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_adfind_discovery.yml
@@ -47,7 +47,6 @@ tags:
     - attack.domain_trust_discovery
     - attack.T1018
     - attack.T1482
-    - attack.TT1482
     - attack.T1069.002
     - attack.T1087.002
     - attack.s0552


### PR DESCRIPTION
Among the tags specified in the sigma rule is "attack.TT1482", but I think this tag is incorrect.