### PR TITLE
Fixed formatting in rules to prevent exceptions.

### DIFF
--- a/rules/network/zeek/zeek_smb_mapping_invoke-sharefinder_discovery.yml
+++ b/rules/network/zeek/zeek_smb_mapping_invoke-sharefinder_discovery.yml
@@ -8,7 +8,7 @@ references:
     - https://thedfirreport.com/2023/01/23/sharefinder-how-threat-actors-discover-file-shares
 
 author: TheDFIRReport
-date: 01/22/2023
+date: 2023/01/22
 
 tags:
     - attack.discovery

--- a/rules/windows/builtin/win_security_invoke_sharefinder_discovery.yml
+++ b/rules/windows/builtin/win_security_invoke_sharefinder_discovery.yml
@@ -8,7 +8,7 @@ references:
     - https://thedfirreport.com/2023/01/23/sharefinder-how-threat-actors-discover-file-shares
 
 author: TheDFIRReport
-date: 01/22/2023
+date: 2023/01/22
 
 tags:
     - attack.discovery

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke-sharefinder_discovery.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke-sharefinder_discovery.yml
@@ -8,7 +8,7 @@ references:
     - https://powersploit.readthedocs.io/en/stable/Recon/README/
 
 author: TheDFIRReport
-date: 01/22/2023
+date: 2023/01/22
 
 tags:
     - attack.discovery

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_sharefinder_discovery.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_sharefinder_discovery.yml
@@ -8,7 +8,7 @@ references:
     - https://powersploit.readthedocs.io/en/stable/Recon/README/
 
 author: TheDFIRReport
-date: 01/23/2023
+date: 2023/01/23
 
 tags:
     - attack.discovery

--- a/rules/windows/process_creation/proc_creation_win_registry_query_for_wdigest.yml
+++ b/rules/windows/process_creation/proc_creation_win_registry_query_for_wdigest.yml
@@ -8,7 +8,7 @@ references:
 date: 2022/06/05
 tags:
     - attack.discovery
-    - t1012
+    - attack.t1012
 logsource:
     category: process_creation
     product: windows


### PR DESCRIPTION
This PR addresses the following issues:

- The date field for some rules was in the incorrect format, causing a `SigmaDateError` exception when loading the rule: #21.
- A tag in `proc_creation_win_registry_query_for_wdigest.yml` was in the incorrect format, causing a `SigmaValueError` exception when loading the rule: #22