### PR TITLE
Adding fixes to some ATT&CK tags

### DIFF
--- a/rules/network/zeek/zeek_smb_files_rclone_smb_share_exfiltration.yml
+++ b/rules/network/zeek/zeek_smb_files_rclone_smb_share_exfiltration.yml
@@ -20,4 +20,4 @@ falsepositives:
 level: medium
 tags:
   - attack.exfiltration
-  - attack.t567.002
+  - attack.T1567.002

--- a/rules/windows/process_creation/proc_creation_win_flawed_grace_cmd_injection.yml
+++ b/rules/windows/process_creation/proc_creation_win_flawed_grace_cmd_injection.yml
@@ -28,5 +28,5 @@ falsepositives:
 level: high
 tags:
     - attack.attack.defense_evasion #TA0005
-    - attack.T1631
+    - attack.T1055
     - dist.public

--- a/rules/windows/process_creation/proc_creation_win_mofcomp_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_mofcomp_execution.yml
@@ -24,5 +24,5 @@ falsepositives:
   - System administrator activities
 level: high
 tags:
-  - attack.execution
-  - attack.t1546.003
+  - attack.defense_evasion
+  - attack.T1218

--- a/rules/windows/process_creation/proc_creation_win_registry_query_for_wdigest.yml
+++ b/rules/windows/process_creation/proc_creation_win_registry_query_for_wdigest.yml
@@ -8,7 +8,7 @@ references:
 date: 2022/06/05
 tags:
     - attack.discovery
-    - t1012
+    - attack.t1012
 logsource:
     category: process_creation
     product: windows


### PR DESCRIPTION
## What Changed
- Fixed some tags with ATT&CK techniques
- FlawedGrace spawning threat injection target: T1631 is ATT&CK for Mobile's technique ID, changed to the Enterprise's TID
- MOFComp Execution: T1546.003 maps to Persistence or Privilege Escalation but I think T1218 captures the execution aspect for Defense Evasion