### PR TITLE
formatting update

### DIFF
--- a/deprecated/win_security_invoke_sharefinder_discovery.yml
+++ b/deprecated/win_security_invoke_sharefinder_discovery.yml
@@ -7,8 +7,8 @@ references:
     - https://powersploit.readthedocs.io/en/stable/Recon/README/
     - https://thedfirreport.com/2023/01/23/sharefinder-how-threat-actors-discover-file-shares
 author: TheDFIRReport
-date: 2023/01/22
-modified: 2024/02/22
+date: 2023-01-22
+modified: 2024-02-22
 tags:
     - attack.discovery
     - attack.t1135

--- a/deprecated/zeek_smb_mapping_invoke-sharefinder_discovery.yml
+++ b/deprecated/zeek_smb_mapping_invoke-sharefinder_discovery.yml
@@ -6,10 +6,9 @@ description: |
 references:
     - https://powersploit.readthedocs.io/en/stable/Recon/README/
     - https://thedfirreport.com/2023/01/23/sharefinder-how-threat-actors-discover-file-shares
-
 author: TheDFIRReport
-date: 2023/01/22
-modified: 2024/02/22
+date: 2023-01-22
+modified: 2024-02-22
 tags:
     - attack.discovery
     - attack.t1135
@@ -21,7 +20,7 @@ detection:
         path|endswith:
             #- \$IPC Too likely to result in false positive hits due to normal behavior
             - \$C
-            - \$ADMIN 
+            - \$ADMIN
     timeframe: 30s
     condition: selection | count(path) by src_ip > 30
 falsepositives:

--- a/rules/network/zeek/zeek_http_webshell_usage_with_manageengine_supportcenter_plus.yml
+++ b/rules/network/zeek/zeek_http_webshell_usage_with_manageengine_supportcenter_plus.yml
@@ -3,8 +3,8 @@ id: c1717e0b-e364-4032-bb8e-1bd112ba4058
 status: experimental
 description: Detection of a webshell in a ManageEngine internet accessible directory.
 author: iiamaleks,TheDFIRReport
-date: 2022/06/06
-modified: 2023/01/08
+date: 2022-06-06
+modified: 2023-01-08
 references:
     - https://thedfirreport.com/2022/06/06/will-the-real-msiexec-please-stand-up-exploit-leads-to-data-exfiltration/
 logsource:

--- a/rules/network/zeek/zeek_smb_files_potential_smb_dll_lateral_movement.yml
+++ b/rules/network/zeek/zeek_smb_files_potential_smb_dll_lateral_movement.yml
@@ -3,8 +3,8 @@ id: 8fe1524e-8c97-404c-9dee-090929a315c4
 status: experimental
 description: Detection of potential us of SMB to transfer DLL's into the ProgramData folder of hosts for purposes of lateral movement.
 author: TheDFIRReport
-date: 2022/09/12
-modified: 2023/01/08
+date: 2022-09-12
+modified: 2023-01-08
 references:
     - https://thedfirreport.com/
 logsource:

--- a/rules/network/zeek/zeek_smb_files_qbot_lateral_dll.yml
+++ b/rules/network/zeek/zeek_smb_files_qbot_lateral_dll.yml
@@ -3,8 +3,8 @@ id: 3eaa2cee-2dfb-46e9-98f6-3782aab30f38
 status: experimental
 description: Detection of potential us of SMB to transfer DLL's into the C$ folder of hosts unique to Qbot malware for purposes of lateral movement.
 author: TheDFIRReport
-date: 2022/09/12
-modified: 2024/02/23
+date: 2022-09-12
+modified: 2024-02-23
 references:
     - https://thedfirreport.com/2022/10/31/follina-exploit-leads-to-domain-compromise/
 logsource:

--- a/rules/network/zeek/zeek_smb_files_rclone_smb_share_exfiltration.yml
+++ b/rules/network/zeek/zeek_smb_files_rclone_smb_share_exfiltration.yml
@@ -3,8 +3,8 @@ id: 889bc648-5164-44f4-9388-fb5d6b58a7b2
 status: experimental
 description: Detection of a exfiltration activity using rclone from Windows network shares using SMB.
 author: TheDFIRReport
-date: 2022/09/12
-modified: 2023/01/08
+date: 2022-09-12
+modified: 2023-01-08
 references:
     - https://thedfirreport.com/
 logsource:

--- a/rules/network/zeek/zeek_ssh_ssh_over_port_443_with_known_server_and_client_strings.yml
+++ b/rules/network/zeek/zeek_ssh_ssh_over_port_443_with_known_server_and_client_strings.yml
@@ -3,8 +3,8 @@ id: 3c5791a2-8f29-413d-b511-90918ecb33b7
 status: experimental
 description: Will detect the presence of known SSH client and SSH server strings that have been used for SSH tunneling.
 author: iiamaleks,TheDFIRReport
-date: 2022/06/06
-modified: 2024/02/23
+date: 2022-06-06
+modified: 2024-02-23
 references:
     - https://thedfirreport.com/2022/06/06/will-the-real-msiexec-please-stand-up-exploit-leads-to-data-exfiltration/
 logsource:

--- a/rules/windows/builtin/security/win_security_netscan_share_enum_write_check.yml
+++ b/rules/windows/builtin/security/win_security_netscan_share_enum_write_check.yml
@@ -3,7 +3,7 @@ id: 8a0d153f-b4e4-4ea7-9335-892dfbe17221
 status: Experimental
 description: Detects the creation of unique artifacts created by SoftPerfect NetScan when performing write-access checking on enumerated network shares
 author: "@pcscout, @TheDFIRReport"
-date: 2024/01/27
+date: 2024-01-27
 references:
     - https://thedfirreport.com/2024/01/29/buzzing-on-christmas-eve-trigona-ransomware-in-3-hours/
     - https://www.softperfect.com.cach3.com/board/read.php%3F12,10134,12202.html

--- a/rules/windows/builtin/system/service_control_manager/win_system_qbot_exec_via_scheduled_task_with_c.yml
+++ b/rules/windows/builtin/system/service_control_manager/win_system_qbot_exec_via_scheduled_task_with_c.yml
@@ -5,8 +5,8 @@ status: test
 author: tas_kmanager, TheDFIRReport
 references:
     - https://thedfirreport.com/2022/02/07/qbot-likes-to-move-it-move-it/
-date: 2022/02/06
-modified: 2023/01/08
+date: 2022-02-06
+modified: 2023-01-08
 logsource:
     product: windows
     service: system

--- a/rules/windows/builtin/system/service_control_manager/win_system_service_disable_defender.yml
+++ b/rules/windows/builtin/system/service_control_manager/win_system_service_disable_defender.yml
@@ -5,7 +5,7 @@ description: Detects Windows Defender disabling service installation
 references:
    - https://thedfirreport.com/2024/02/26/seo-poisoning-to-domain-control-the-gootloader-saga-continues/
 author: _pete_0, TheDFIRReport
-date: 2024/02/17
+date: 2024-02-17
 tags:
     - attack.execution
     - attack.t1569.002

--- a/rules/windows/dns_query/dns_query_for_ufileio_domain.yml
+++ b/rules/windows/dns_query/dns_query_for_ufileio_domain.yml
@@ -3,8 +3,8 @@ id: 1cbbeaaf-3c8c-4e4c-9d72-49485b6a176b
 description: Detects DNS queries for subdomains used for upload to ufile.io
 status: experimental
 author: yatinwad and TheDFIRReport
-date: 2021/12/13
-modified: 2024/02/23
+date: 2021-12-13
+modified: 2024-02-23
 references:
     - https://thedfirreport.com/2021/12/13/diavol-ransomware/
 tags:

--- a/rules/windows/dns_query/dns_query_win_network_anydesk.yml
+++ b/rules/windows/dns_query/dns_query_win_network_anydesk.yml
@@ -5,8 +5,8 @@ description: Detects use of AnyDesk
 author: _pete_0, TheDFIRReport
 references:
     - https://support.anydesk.com/knowledge/firewall
-date: 2022/05/06
-modified: 2022/05/06
+date: 2022-05-06
+modified: 2022-05-06
 logsource:
     category: dns_query
     product: windows

--- a/rules/windows/dns_query/dns_query_win_network_splashtop.yml
+++ b/rules/windows/dns_query/dns_query_win_network_splashtop.yml
@@ -6,8 +6,8 @@ author: _pete_0, TheDFIRReport
 references:
     - https://support-splashtopbusiness.splashtop.com/hc/en-us/articles/212724303-Why-does-the-Splashtop-software-show-unable-to-reach-Splashtop-servers-
     - https://thedfirreport.com/2022/04/04/stolen-images-campaign-ends-in-conti-ransomware/
-date: 2022/05/06
-modified: 2022/05/06
+date: 2022-05-06
+modified: 2022-05-06
 logsource:
     category: dns_query
     product: windows

--- a/rules/windows/file_event/file_event_win_nullsoft_installer_execution.yml
+++ b/rules/windows/file_event/file_event_win_nullsoft_installer_execution.yml
@@ -2,8 +2,8 @@ title: Nullsoft Scriptable Installer Script (NSIS) file creation
 id: b95288d8-020a-4df0-95cb-d2d3a806ab11
 description: Detects the creation of the NSIS System plugin library, indicative of an NSIS script execution.
 status: experimental
-date: 2023/06/12
-modified: 2024/02/23
+date: 2023-06-12
+modified: 2024-02-23
 author: "Maxime THIEBAUT (@0xThiebaut), @TheDFIRReport"
 references:
     - https://thedfirreport.com/2023/06/12/a-truly-graceful-wipe-out

--- a/rules/windows/image_load/image_load_nullsoft_installer.yml
+++ b/rules/windows/image_load/image_load_nullsoft_installer.yml
@@ -2,8 +2,8 @@ title: Nullsoft Scriptable Installer Script (NSIS) execution
 id: 221f15de-1cce-40b2-a766-2873938198c6
 description: Detects the loading of the NSIS System plugin library, indicative of an NSIS script execution.
 status: experimental
-date: 2023/06/12
-modified: 2024/02/23
+date: 2023-06-12
+modified: 2024-02-23
 author: "Maxime THIEBAUT (@0xThiebaut), @TheDFIRReport"
 references:
     - https://thedfirreport.com/2023/06/12/a-truly-graceful-wipe-out

--- a/rules/windows/powershell/powershell_module/posh_pm_enable_wdigest_using_powershell.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_enable_wdigest_using_powershell.yml
@@ -2,7 +2,7 @@ title: Enable WDigest using PowerShell (ps_module)
 id: c677394a-1e3e-4ab5-a6a8-295bf0b71137
 description: Rule to detect registry modifications to enable WDigest using powershell script modules.
 status: experimental
-date: 2022/06/05
+date: 2022-06-05
 author: The DFIR Report
 references:
     - https://thedfirreport.com/2022/06/06/will-the-real-msiexec-please-stand-up-exploit-leads-to-data-exfiltration/

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke-sharefinder_discovery.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke-sharefinder_discovery.yml
@@ -7,8 +7,8 @@ references:
     - https://thedfirreport.com/2023/01/23/sharefinder-how-threat-actors-discover-file-shares
     - https://powersploit.readthedocs.io/en/stable/Recon/README/
 author: TheDFIRReport
-date: 2023/01/22
-modified: 2024/02/23
+date: 2023-01-22
+modified: 2024-02-23
 tags:
     - attack.discovery
     - attack.t1135

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_sharefinder_discovery.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_sharefinder_discovery.yml
@@ -7,8 +7,8 @@ references:
     - https://thedfirreport.com/2023/01/23/sharefinder-how-threat-actors-discover-file-shares/
     - https://powersploit.readthedocs.io/en/stable/Recon/README/
 author: TheDFIRReport
-date: 2023/01/23
-modified: 2024/02/23
+date: 2023-01-23
+modified: 2024-02-23
 tags:
     - attack.discovery
     - attack.t1135

--- a/rules/windows/process_creation/proc_creation_aws_cli_exfil.yml
+++ b/rules/windows/process_creation/proc_creation_aws_cli_exfil.yml
@@ -6,8 +6,8 @@ references:
     - https://thedfirreport.com/2024/04/29/from-icedid-to-dagon-locker-ransomware-in-29-days/
     - https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/cp.html
 author: TheDFIRReport
-date: 2024/03/22
-modified: 2024/04/23
+date: 2024-03-22
+modified: 2024-04-23
 tags:
     - attack.exfiltration
     - attack.t1567.002

--- a/rules/windows/process_creation/proc_creation_java_script_file_exec_msdos_notation.yml
+++ b/rules/windows/process_creation/proc_creation_java_script_file_exec_msdos_notation.yml
@@ -8,7 +8,7 @@ description: Detects script execution using MSDOS 8.3 File names
 references:
    - https://thedfirreport.com/2024/02/26/seo-poisoning-to-domain-control-the-gootloader-saga-continues/
 author: _pete_0, TheDFIRReport
-date: 2024/02/13
+date: 2024-02-13
 tags:
     - attack.defense_evasion
     - attack.t1059

--- a/rules/windows/process_creation/proc_creation_win_adfind_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_adfind_discovery.yml
@@ -3,8 +3,8 @@ id: 50046619-1037-49d7-91aa-54fc92923604
 status: stable
 description: AdFind has been seen in numerous intrusions. The threat actor(s) ran these commands.
 author: 'The DFIR Report'
-date: 2022/05/14
-modified: 2024/02/23
+date: 2022-05-14
+modified: 2024-02-23
 references:
     - https://thedfirreport.com/2020/05/08/adfind-recon/
     - https://thedfirreport.com/?s=adfind

--- a/rules/windows/process_creation/proc_creation_win_ateraagent_malicious_installations.yml
+++ b/rules/windows/process_creation/proc_creation_win_ateraagent_malicious_installations.yml
@@ -2,8 +2,8 @@ title: AteraAgent malicious installations
 id: fb0f2d48-269d-473e-9afc-c540a16a990f
 description: Detects potentially malicious AteraAgent installations when the IntegratorLogin parameter is used to register a non-business email.
 status: experimental
-date: 2022/09/12
-modified: 2024/02/23
+date: 2022-09-12
+modified: 2024-02-23
 author: 'kostastsale, TheDFIRReport'
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/proc_creation_win_bumblebee_wmiprvse_execution_pattern.yml
+++ b/rules/windows/process_creation/proc_creation_win_bumblebee_wmiprvse_execution_pattern.yml
@@ -5,7 +5,7 @@ description: Detects Bumblebee WmiPrvSE parent process manipulation
 author:  TheDFIRReport
 references:
     - https://thedfirreport.com/2022/09/26/bumblebee-round-two/
-date: 2022/09/26
+date: 2022-09-26
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_chcp_codepage_locale_lookup.yml
+++ b/rules/windows/process_creation/proc_creation_win_chcp_codepage_locale_lookup.yml
@@ -6,8 +6,8 @@ author: _pete_0, TheDFIRReport
 references:
     - https://thedfirreport.com/2022/04/04/stolen-images-campaign-ends-in-conti-ransomware/
     - https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/chcp
-date: 2022/02/21
-modified: 2022/02/21
+date: 2022-02-21
+modified: 2022-02-21
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_cmdkey.yml
+++ b/rules/windows/process_creation/proc_creation_win_cmdkey.yml
@@ -5,7 +5,7 @@ description: Detects the use of cmdkey to add, remove, or list credentials.
 references:
     - https://thedfirreport.com/2023/10/30/netsupport-intrusion-results-in-domain-compromise
     - https://ss64.com/nt/cmdkey.html#:~:text=CMDKEY.exe%20(Windows%202003%2B),and%20password%20to%20the%20list.
-date: 2023/10/27
+date: 2023-10-27
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_cobaltstrike_operator_bloopers_cmds.yml
+++ b/rules/windows/process_creation/proc_creation_win_cobaltstrike_operator_bloopers_cmds.yml
@@ -5,8 +5,8 @@ description: Detects use of Cobalt Strike commands accidentally entered in the C
 author: _pete_0, TheDFIRReport
 references:
     - https://hstechdocs.helpsystems.com/manuals/cobaltstrike/current/userguide/content/cobalt-4-5-user-guide.pdf
-date: 2022/05/06
-modified: 2022/05/06
+date: 2022-05-06
+modified: 2022-05-06
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_cobaltstrike_operator_bloopers_modules.yml
+++ b/rules/windows/process_creation/proc_creation_win_cobaltstrike_operator_bloopers_modules.yml
@@ -6,8 +6,8 @@ author: _pete_0, TheDFIRReport
 references:
     - https://hstechdocs.helpsystems.com/manuals/cobaltstrike/current/userguide/content/cobalt-4-5-user-guide.pdf
     - https://thedfirreport.com/2021/10/04/bazarloader-and-the-conti-leaks/
-date: 2022/05/06
-modified: 2022/05/06
+date: 2022-05-06
+modified: 2022-05-06
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_conhost_headless.yml
+++ b/rules/windows/process_creation/proc_creation_win_conhost_headless.yml
@@ -8,7 +8,7 @@ author: TheDFIRReport
 references:
     - https://thedfirreport.com/
     - 'Event 25197'
-date: 2023/10/03
+date: 2023-10-03
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_custom_cobalt_strike_command_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_custom_cobalt_strike_command_execution.yml
@@ -6,8 +6,8 @@ author: 'Kostastsale, TheDFIRReport'
 references:
     - https://thedfirreport.com/2022/05/09/seo-poisoning-a-gootloader-story/
     - https://gist.github.com/mgeeky/3b11169ab77a7de354f4111aa2f0df38
-date: 2022/05/09
-modified: 2024/02/23
+date: 2022-05-09
+modified: 2024-02-23
 logsource:
     product: windows
     category: process_creation

--- a/rules/windows/process_creation/proc_creation_win_defaultaccount_usage.yml
+++ b/rules/windows/process_creation/proc_creation_win_defaultaccount_usage.yml
@@ -2,8 +2,8 @@ title: Default Account Usage
 id: dca5d253-d738-4ec4-b530-381ece784d42
 description: Threat actor (APT35) created user, enabled it, set password, add to admins and remote desktop users.
 author: 'The DFIR Report'
-date: 2022/5/14
-modified: 2023/01/08
+date: 2022-05-14
+modified: 2023-01-08
 references:
     - https://thedfirreport.com/2022/03/21/apt35-automates-initial-access-using-proxyshell/
 logsource:

--- a/rules/windows/process_creation/proc_creation_win_deleting_windows_defender_scheduled_tasks.yml
+++ b/rules/windows/process_creation/proc_creation_win_deleting_windows_defender_scheduled_tasks.yml
@@ -5,8 +5,8 @@ description: Detects the deletion of scheduled tasks related to Windows Defender
 author: 'Kostastsale, TheDFIRReport'
 references:
     - https://thedfirreport.com/2022/05/09/seo-poisoning-a-gootloader-story/
-date: 2022/05/09
-modified: 2024/02/23
+date: 2022-05-09
+modified: 2024-02-23
 logsource:
     product: windows
     category: process_creation

--- a/rules/windows/process_creation/proc_creation_win_driverquery_lookup.yml
+++ b/rules/windows/process_creation/proc_creation_win_driverquery_lookup.yml
@@ -6,7 +6,7 @@ author: _pete_0, TheDFIRReport
 references:
     - https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/driverquery
     - https://thedfirreport.com/2023/01/09/unwrapping-ursnifs-gifts
-date: 2023/01/08
+date: 2023-01-08
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_emotet_child_process_spawn_pattern.yml
+++ b/rules/windows/process_creation/proc_creation_win_emotet_child_process_spawn_pattern.yml
@@ -6,7 +6,7 @@ author:  TheDFIRReport
 references:
     - https://thedfirreport.com/2022/11/28/emotet-strikes-again-lnk-file-leads-to-domain-wide-ransomware/
     - Case 15184
-date: 2022/10/03
+date: 2022-10-03
 logsource:
   category: process_creation
   product: windows

--- a/rules/windows/process_creation/proc_creation_win_enable_wdigest_using_powershell.yml
+++ b/rules/windows/process_creation/proc_creation_win_enable_wdigest_using_powershell.yml
@@ -5,7 +5,7 @@ description: Rule to detect registry modifications to enable WDigest using power
 author: The DFIR Report
 references:
     - https://thedfirreport.com/2022/06/06/will-the-real-msiexec-please-stand-up-exploit-leads-to-data-exfiltration/
-date: 2022/06/06
+date: 2022-06-06
 tags:
     - attack.defense_evasion
     - attack.t1112

--- a/rules/windows/process_creation/proc_creation_win_enabling_rdp_service_via_reg_command_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_enabling_rdp_service_via_reg_command_execution.yml
@@ -5,8 +5,8 @@ description: Detects the execution of reg.exe and subsequent command line argume
 author: 'Kostastsale, TheDFIRReport'
 references:
     - https://thedfirreport.com/2022/02/21/qbot-and-zerologon-lead-to-full-domain-compromise/
-date: 2022/02/12
-modified: 2023/01/08
+date: 2022-02-12
+modified: 2023-01-08
 logsource:
   product: windows
   category: process_creation

--- a/rules/windows/process_creation/proc_creation_win_enabling_restricted_admin_mode.yml
+++ b/rules/windows/process_creation/proc_creation_win_enabling_restricted_admin_mode.yml
@@ -5,8 +5,8 @@ description: Detects the registry modification to enable restricted admin mode u
 author: 'Kostastsale, TheDFIRReport'
 references:
     - https://thedfirreport.com/2022/05/09/seo-poisoning-a-gootloader-story/
-date: 2022/05/09
-modified: 2023/01/08
+date: 2022-05-09
+modified: 2023-01-08
 logsource:
     product: windows
     category: process_creation

--- a/rules/windows/process_creation/proc_creation_win_exchange_webshell_creation.yml
+++ b/rules/windows/process_creation/proc_creation_win_exchange_webshell_creation.yml
@@ -2,8 +2,8 @@ title: Exchange WebShell Creation
 id: 3086329b-245b-4b91-a0f7-bed9b5438cf6
 description: These commands were used to create a WebShell by exploiting ProxyShell vulnerabilities
 author: 'The DFIR Report'
-date: 2022/05/14
-modified: 2024/02/23
+date: 2022-05-14
+modified: 2024-02-23
 references:
     - https://thedfirreport.com/2022/03/21/apt35-automates-initial-access-using-proxyshell/
 logsource:

--- a/rules/windows/process_creation/proc_creation_win_execution_of_zerologon_poc_executable.yml
+++ b/rules/windows/process_creation/proc_creation_win_execution_of_zerologon_poc_executable.yml
@@ -6,8 +6,8 @@ author: 'Kostastsale, TheDFIRReport'
 references:
     - https://thedfirreport.com/2021/11/01/from-zero-to-domain-admin/
     - https://thedfirreport.com/2022/02/21/qbot-and-zerologon-lead-to-full-domain-compromise/
-date: 2022/02/12
-modified: 2024/02/23
+date: 2022-02-12
+modified: 2024-02-23
 logsource:
     product: windows
     category: process_creation

--- a/rules/windows/process_creation/proc_creation_win_flawed_grace_cmd_injection.yml
+++ b/rules/windows/process_creation/proc_creation_win_flawed_grace_cmd_injection.yml
@@ -2,8 +2,8 @@ title: FlawedGrace spawning threat injection target
 id: 295e71e5-38c9-4a59-90dd-9fa7bf617b4b
 description: Detecting the command FlawedGrace is using for the purpose of injecting into it the spawned process, in this case the cmd.exe process.
 status: experimental
-date: 2023/06/12
-modified: 2024/02/23
+date: 2023-06-12
+modified: 2024-02-23
 author: "@kostastsale, @TheDFIRReport"
 references:
     - https://thedfirreport.com/2023/06/12/a-truly-graceful-wipe-out

--- a/rules/windows/process_creation/proc_creation_win_hiding_local_user_accounts.yml
+++ b/rules/windows/process_creation/proc_creation_win_hiding_local_user_accounts.yml
@@ -5,8 +5,8 @@ status: experimental
 references:
     - https://thedfirreport.com/2022/07/11/select-xmrig-from-sqlserver/
 author: 'Kostastsale, TheDFIRReport'
-date: 2022/07/11
-modified: 2024/02/23
+date: 2022-07-11
+modified: 2024-02-23
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_lazagne_dumping_credentials.yml
+++ b/rules/windows/process_creation/proc_creation_win_lazagne_dumping_credentials.yml
@@ -6,8 +6,8 @@ author: 'Kostastsale, TheDFIRReport'
 references:
     - https://thedfirreport.com/2022/05/09/seo-poisoning-a-gootloader-story/
     - https://github.com/AlessandroZ/LaZagne/blob/master/Windows/lazagne/config/execute_cmd.py
-date: 2022/05/09
-modified: 2024/02/23
+date: 2022-05-09
+modified: 2024-02-23
 logsource:
     product: windows
     category: process_creation

--- a/rules/windows/process_creation/proc_creation_win_mimkiatz_command_line_with_ticket_export.yml
+++ b/rules/windows/process_creation/proc_creation_win_mimkiatz_command_line_with_ticket_export.yml
@@ -3,7 +3,7 @@ id: 48e1dd43-c42f-4b3b-9011-a0ea1fab6b03
 status: experimental
 description: Detection of well-known mimikatz command line arguments. Added more commandline indicators from referenced rule by author - Teymur Kheirkhabarov, oscd.community
 author: thedfirreport
-date: 2021/01/18
+date: 2021-01-18
 references:
     - https://www.slideshare.net/heirhabarov/hunting-for-credentials-dumping-in-windows-environment
     - https://github.com/Neo23x0/sigma/blob/master/rules/windows/process_creation/win_mimikatz_command_line.yml

--- a/rules/windows/process_creation/proc_creation_win_mofcomp_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_mofcomp_execution.yml
@@ -5,8 +5,8 @@ description: Detects abuse of mofcomp to load WMI classes i.e. to create WMI eve
 author: _pete_0, TheDFIRReport
 references:
     - https://thedfirreport.com/2022/07/11/select-xmrig-from-sqlserver/
-date: 2022/07/11
-modified: 2022/07/11
+date: 2022-07-11
+modified: 2022-07-11
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_mshta.yml
+++ b/rules/windows/process_creation/proc_creation_win_mshta.yml
@@ -6,7 +6,7 @@ author: TheDFIRReport
 references:
     - https://lolbas-project.github.io/lolbas/Binaries/Mshta/
     - https://thedfirreport.com/2023/01/09/unwrapping-ursnifs-gifts
-date: 2023/01/08
+date: 2023-01-08
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_nim_pth_tooling.yml
+++ b/rules/windows/process_creation/proc_creation_win_nim_pth_tooling.yml
@@ -3,8 +3,8 @@ id: d938de18-7f57-4c9c-93b9-a621c746d594
 status: experimental
 description: Detection of NIM Tooling that Creates a Remote User (pth_createusers.exe) and Adds them to Local Admins group (pth_addadmin.exe)
 author: 'The DFIR Report'
-date: 2023/10/27
-modified: 2023/10/27
+date: 2023-10-27
+modified: 2023-10-27
 references:
     - https://thedfirreport.com/2023/10/30/netsupport-intrusion-results-in-domain-compromise
 logsource:

--- a/rules/windows/process_creation/proc_creation_win_nslookup_local.yml
+++ b/rules/windows/process_creation/proc_creation_win_nslookup_local.yml
@@ -6,7 +6,7 @@ author: _pete_0, TheDFIRReport
 references:
     - https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/nslookup
     - https://thedfirreport.com/2023/01/09/unwrapping-ursnifs-gifts
-date: 2023/01/08
+date: 2023-01-08
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_psexec_custom_named_service_binary.yml
+++ b/rules/windows/process_creation/proc_creation_win_psexec_custom_named_service_binary.yml
@@ -5,8 +5,8 @@ description: PSEXEC executed with non default service binary name
 references:
     - https://thedfirreport.com/
 author: 'TheDFIRReport'
-date: 2022/04/24
-modified: 2023/01/08
+date: 2022-04-24
+modified: 2023-01-08
 logsource:
     product: windows
     category: process_creation

--- a/rules/windows/process_creation/proc_creation_win_qbot_exec_via_scheduled_task.yml
+++ b/rules/windows/process_creation/proc_creation_win_qbot_exec_via_scheduled_task.yml
@@ -5,8 +5,8 @@ description: Detects the process creation from Scheduled Task with REGSVR32 (reg
 author: tas_kmanager, TheDFIRReport
 references:
     - https://thedfirreport.com/2022/02/07/qbot-likes-to-move-it-move-it/
-date: 2022/02/06
-modified: 2024/02/23
+date: 2022-02-06
+modified: 2024-02-23
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_registry_query_for_wdigest.yml
+++ b/rules/windows/process_creation/proc_creation_win_registry_query_for_wdigest.yml
@@ -5,8 +5,8 @@ description: Rule to detect discovery activity for WDigest registry settings
 author: The DFIR Report
 references:
     - https://thedfirreport.com/2022/06/06/will-the-real-msiexec-please-stand-up-exploit-leads-to-data-exfiltration/
-date: 2022/06/05
-modified: 2024/02/23
+date: 2022-06-05
+modified: 2024-02-23
 tags:
     - attack.discovery
     - attack.t1012

--- a/rules/windows/process_creation/proc_creation_win_remote_dir_view.yml
+++ b/rules/windows/process_creation/proc_creation_win_remote_dir_view.yml
@@ -2,8 +2,8 @@ title: Viewing remote directories
 id: bca1fab7-5640-489d-a161-e154fb6ba4f8
 description: Detecting the use of dir command to inspect directories on the remote host.
 status: experimental
-date: 2023/06/12
-modified: 2024/02/23
+date: 2023-06-12
+modified: 2024-02-23
 author: "@kostastsale, @TheDFIRReport"
 references:
     - https://thedfirreport.com/2023/06/12/a-truly-graceful-wipe-out

--- a/rules/windows/process_creation/proc_creation_win_remote_tasklist.yml
+++ b/rules/windows/process_creation/proc_creation_win_remote_tasklist.yml
@@ -2,8 +2,8 @@ title: List remote processes using tasklist
 id: 80a56507-6778-4d04-8346-320a70358f2c
 description: Detecting the use of tasklist to display processes of remote hosts using the /S parameter.
 status: experimental
-date: 2023/06/12
-modified: 2024/02/23
+date: 2023-06-12
+modified: 2024-02-23
 author: "@kostastsale, @TheDFIRReport"
 references:
     - https://thedfirreport.com/2023/06/12/a-truly-graceful-wipe-out

--- a/rules/windows/process_creation/proc_creation_win_renamed_autohotkey_binary.yml
+++ b/rules/windows/process_creation/proc_creation_win_renamed_autohotkey_binary.yml
@@ -6,7 +6,7 @@ references:
     - https://attack.mitre.org/techniques/T1036/
     - https://thedfirreport.com/2023/02/06/collect-exfiltrate-sleep-repeat/
 author: TheDFIRReport
-date: 2023/02/05
+date: 2023-02-05
 tags:
     - attack.defense_evasion
     - attack.t1036.003

--- a/rules/windows/process_creation/proc_creation_win_scheduled_task_executing_powershell_ecoded_payload_from_registry.yml
+++ b/rules/windows/process_creation/proc_creation_win_scheduled_task_executing_powershell_ecoded_payload_from_registry.yml
@@ -5,8 +5,8 @@ description: Detects the creation of a schtask that executes a base64 encoded pa
 author: 'Kostastsale, TheDFIRReport'
 references:
     - https://thedfirreport.com/2022/02/21/qbot-and-zerologon-lead-to-full-domain-compromise/
-date: 2022/02/12
-modified: 2023/01/08
+date: 2022-02-12
+modified: 2023-01-08
 logsource:
     product: windows
     category: process_creation

--- a/rules/windows/process_creation/proc_creation_win_software_byot.yml
+++ b/rules/windows/process_creation/proc_creation_win_software_byot.yml
@@ -5,8 +5,8 @@ description: Detects use of custom scripts i.e. BAT files.
 author: _pete_0, TheDFIRReport
 references:
     - https://thedfirreport.com/
-date: 2022/06/10
-modified: 2024/02/23
+date: 2022-06-10
+modified: 2024-02-23
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_software_splashtop.yml
+++ b/rules/windows/process_creation/proc_creation_win_software_splashtop.yml
@@ -6,8 +6,8 @@ author: _pete_0, TheDFIRReport
 references:
     - https://support-splashtopbusiness.splashtop.com/hc/en-us/articles/212724303-Why-does-the-Splashtop-software-show-unable-to-reach-Splashtop-servers-
     - https://thedfirreport.com/2022/04/04/stolen-images-campaign-ends-in-conti-ransomware/
-date: 2022/05/06
-modified: 2022/05/06
+date: 2022-05-06
+modified: 2022-05-06
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_suspicious_commands_by_sql_server.yml
+++ b/rules/windows/process_creation/proc_creation_win_suspicious_commands_by_sql_server.yml
@@ -5,8 +5,8 @@ status: experimental
 author: 'TheDFIRReport'
 references:
     - https://thedfirreport.com/2022/07/11/select-xmrig-from-sqlserver
-date: 2022/07/11
-modified: 2022/12/16
+date: 2022-07-11
+modified: 2022-12-16
 tags:
     - attack.initial_access
     - attack.persistence

--- a/rules/windows/process_creation/proc_creation_win_suspicious_scheduled_task_creation_to_execute_lolbins.yml
+++ b/rules/windows/process_creation/proc_creation_win_suspicious_scheduled_task_creation_to_execute_lolbins.yml
@@ -2,8 +2,8 @@ title: Suspicious Scheduled Task Creation to execute LOLbins
 id: e4cae9a5-49a8-46ab-b223-87565b849e64
 status: experimental
 description: Detects command line creation of scheduled tasks using commomly abused LOLbins.
-date: 2021/10/18
-modified: 2024/02/22
+date: 2021-10-18
+modified: 2024-02-22
 author: yatinwad and TheDFIRReport
 tags:
     - attack.persistence

--- a/rules/windows/process_creation/proc_creation_win_system_time_lookup.yml
+++ b/rules/windows/process_creation/proc_creation_win_system_time_lookup.yml
@@ -6,7 +6,7 @@ author: _pete_0, TheDFIRReport
 references:
     - https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/time
     - https://thedfirreport.com/2023/01/09/unwrapping-ursnifs-gifts
-date: 2023/01/08
+date: 2023-01-08
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_uninstall_defender.yml
+++ b/rules/windows/process_creation/proc_creation_win_uninstall_defender.yml
@@ -6,8 +6,8 @@ author: _pete_0, TheDFIRReport
 references:
     - https://learn.microsoft.com/en-us/microsoft-365/security/defender-endpoint/microsoft-defender-antivirus-on-windows-server?view=o365-worldwide
     - https://thedfirreport.com/2023/04/03/malicious-iso-file-leads-to-domain-wide-ransomware
-date: 2023/04/02
-modified: 2024/02/23
+date: 2023-04-02
+modified: 2024-02-23
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_ursnif_loader.yml
+++ b/rules/windows/process_creation/proc_creation_win_ursnif_loader.yml
@@ -6,7 +6,7 @@ author: svch0st, TheDFIRReport
 references:
     - https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/time
     - https://thedfirreport.com/2023/01/09/unwrapping-ursnifs-gifts
-date: 2023/01/08
+date: 2023-01-08
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_winevent_security_query.yml
+++ b/rules/windows/process_creation/proc_creation_win_winevent_security_query.yml
@@ -6,8 +6,8 @@ author: _pete_0, TheDFIRReport
 references:
   - https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-eventlog?view=powershell-5.1
   - https://thedfirreport.com/2023/04/03/malicious-iso-file-leads-to-domain-wide-ransomware
-date: 2023/04/02
-modified: 2024/02/23
+date: 2023-04-02
+modified: 2024-02-23
 logsource:
     category: process_creation
     product: windows


### PR DESCRIPTION
This PR updates the formatting of all sigma rules present in this repo.

- Update the dates to use `-` instead of `/` (follow the ISO 8601 date described in the specs)
- normalize the indentation to 4
- merged unnecessary selections for ease of reading
- removed trailing spaces

While these are mostly cosmetic changes. They do make the rules more readable in my opinion.